### PR TITLE
Vision improvements

### DIFF
--- a/src/main/java/frc/robot/subsystems/shooter/flywheel/FlywheelConstants.java
+++ b/src/main/java/frc/robot/subsystems/shooter/flywheel/FlywheelConstants.java
@@ -16,7 +16,7 @@ public class FlywheelConstants {
   // Motor RPM -> Flywheel RPM
   public static final double velocityConversionFactor = positionConversionFactor;
   public static final double velocityToleranceRPM = 30.0;
-  public static final double passingToleranceRPM = 200.0;
+  public static final double passingToleranceRPM = 60.0;
 
   public static final double kp = 0.0005;
   public static final double ki = 0.0;

--- a/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
@@ -53,12 +53,11 @@ public class VisionConstants {
   public static double maxAmbiguity = 0.3;
   public static double maxZError = 0.75;
   public static double maxSingleTagDistance = 4.0; // Meters
-  public static double maxHeadingDifference = Units.degreesToRadians(20.0); // Radians
 
   // Standard deviation baselines, for 1 meter distance and 1 tag
   // (Adjusted automatically based on distance and # of tags)
   public static double linearStdDevBaseline = 0.5; // Meters
-  public static double angularStdDevBaseline = Units.degreesToRadians(200.0); // Radians
+  public static double angularStdDevBaseline = Units.degreesToRadians(60.0); // Radians
 
   // Bump zone vision boost: temporarily trust vision more after crossing the bump
   // to speed up pose convergence after odometry corruption from airtime

--- a/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
@@ -52,7 +52,6 @@ public class VisionConstants {
   // Basic filtering thresholds
   public static double maxAmbiguity = 0.3;
   public static double maxZError = 0.75;
-  public static double maxSingleTagDistance = 4.0; // Meters
 
   // Standard deviation baselines, for 1 meter distance and 1 tag
   // (Adjusted automatically based on distance and # of tags)

--- a/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
@@ -52,11 +52,19 @@ public class VisionConstants {
   // Basic filtering thresholds
   public static double maxAmbiguity = 0.3;
   public static double maxZError = 0.75;
+  public static double maxSingleTagDistance = 4.0; // Meters
+  public static double maxHeadingDifference = Units.degreesToRadians(20.0); // Radians
 
   // Standard deviation baselines, for 1 meter distance and 1 tag
   // (Adjusted automatically based on distance and # of tags)
-  public static double linearStdDevBaseline = 0.25; // Meters
-  public static double angularStdDevBaseline = Units.degreesToRadians(12.0); // Radians
+  public static double linearStdDevBaseline = 0.5; // Meters
+  public static double angularStdDevBaseline = Units.degreesToRadians(200.0); // Radians
+
+  // Bump zone vision boost: temporarily trust vision more after crossing the bump
+  // to speed up pose convergence after odometry corruption from airtime
+  public static double bumpBoostFactor =
+      0.1; // Std dev multiplier when boosted (lower = more trust)
+  public static double bumpBoostDuration = 2.0; // Seconds of boost after exiting bump zone
 
   // Standard deviation multipliers for each camera
   // (Adjust to trust some cameras more than others)

--- a/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
@@ -9,6 +9,7 @@ package frc.robot.subsystems.vision;
 
 import static frc.robot.subsystems.vision.VisionConstants.*;
 
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -20,10 +21,14 @@ import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Alert.AlertType;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.Constants;
 import frc.robot.subsystems.drive.DriveSubsystem;
 import frc.robot.subsystems.vision.VisionIO.CameraType;
+import frc.robot.util.Zones;
 import java.util.LinkedList;
 import java.util.List;
 import org.littletonrobotics.junction.AutoLogOutputManager;
@@ -80,6 +85,10 @@ public class VisionSubsystem extends SubsystemBase {
   private final VisionIOInputsAutoLogged[] inputs;
   private final Alert[] disconnectedAlerts;
 
+  // Bump zone vision boost state
+  private boolean bumpBoostActive = false;
+  private double bumpBoostExitTimestamp = 0.0;
+
   private VisionSubsystem(VisionIO... io) {
     this.consumer = DriveSubsystem.getInstance()::addVisionMeasurement;
     this.io = io;
@@ -98,6 +107,17 @@ public class VisionSubsystem extends SubsystemBase {
               "Vision camera " + io[i].getName() + " (index " + i + ") is disconnected.",
               AlertType.kError);
     }
+
+    // Set up bump zone trigger to boost vision trust during/after bump crossings
+    Trigger inBumpZone =
+        Zones.bumpZones.contains(DriveSubsystem.getInstance()::getPose).debounce(0.1);
+    inBumpZone.onTrue(Commands.runOnce(() -> bumpBoostActive = true));
+    inBumpZone.onFalse(
+        Commands.runOnce(
+            () -> {
+              bumpBoostActive = false;
+              bumpBoostExitTimestamp = Timer.getTimestamp();
+            }));
 
     AutoLogOutputManager.addObject(this);
   }
@@ -165,8 +185,16 @@ public class VisionSubsystem extends SubsystemBase {
             observation.tagCount() == 0 // Must have at least one tag
                 || (observation.tagCount() == 1
                     && observation.ambiguity() > maxAmbiguity) // Cannot be high ambiguity
+                || (observation.tagCount() == 1
+                    && observation.averageTagDistance()
+                        > maxSingleTagDistance) // Single tag too far
                 || Math.abs(observation.pose().getZ())
                     > maxZError // Must have realistic Z coordinate
+                || Math.abs(
+                        MathUtil.angleModulus(
+                            observation.pose().getRotation().toRotation2d().getRadians()
+                                - DriveSubsystem.getInstance().getRotation().getRadians()))
+                    > maxHeadingDifference // Vision heading disagrees with gyro
 
                 // Must be within the field boundaries
                 || observation.pose().getX() < 0.0
@@ -187,10 +215,25 @@ public class VisionSubsystem extends SubsystemBase {
           continue;
         }
 
+        // Calculate bump boost multiplier for faster convergence after bump crossings
+        double boostMultiplier = 1.0;
+        if (bumpBoostActive) {
+          boostMultiplier = bumpBoostFactor;
+        } else if (bumpBoostExitTimestamp > 0.0) {
+          double elapsed = Timer.getTimestamp() - bumpBoostExitTimestamp;
+          if (elapsed < bumpBoostDuration) {
+            // Cubic decay: stays near bumpBoostFactor for most of the duration, drops off sharply
+            double t = elapsed / bumpBoostDuration;
+            boostMultiplier = bumpBoostFactor + (1.0 - bumpBoostFactor) * (t * t * t);
+          } else {
+            bumpBoostExitTimestamp = 0.0;
+          }
+        }
+
         // Calculate standard deviations
         double stdDevFactor =
             Math.pow(observation.averageTagDistance(), 2.0) / observation.tagCount();
-        double linearStdDev = linearStdDevBaseline * stdDevFactor;
+        double linearStdDev = linearStdDevBaseline * stdDevFactor * boostMultiplier;
         double angularStdDev = angularStdDevBaseline * stdDevFactor;
         if (cameraIndex < cameraStdDevFactors.length) {
           linearStdDev *= cameraStdDevFactors[cameraIndex];
@@ -231,6 +274,9 @@ public class VisionSubsystem extends SubsystemBase {
     Logger.recordOutput(
         "Vision/Summary/RobotPosesRejected", allRobotPosesRejected.toArray(new Pose3d[0]));
     logAllCameraVectors();
+
+    // Log bump boost state
+    Logger.recordOutput("Vision/BumpBoostActive", bumpBoostActive);
 
     // Log balls in hopper
     Logger.recordOutput("Vision/FuelCount", getGamePieceCount());

--- a/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
@@ -184,9 +184,6 @@ public class VisionSubsystem extends SubsystemBase {
             observation.tagCount() == 0 // Must have at least one tag
                 || (observation.tagCount() == 1
                     && observation.ambiguity() > maxAmbiguity) // Cannot be high ambiguity
-                || (observation.tagCount() == 1
-                    && observation.averageTagDistance()
-                        > maxSingleTagDistance) // Single tag too far
                 || Math.abs(observation.pose().getZ())
                     > maxZError // Must have realistic Z coordinate
 

--- a/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
@@ -9,7 +9,6 @@ package frc.robot.subsystems.vision;
 
 import static frc.robot.subsystems.vision.VisionConstants.*;
 
-import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -190,11 +189,6 @@ public class VisionSubsystem extends SubsystemBase {
                         > maxSingleTagDistance) // Single tag too far
                 || Math.abs(observation.pose().getZ())
                     > maxZError // Must have realistic Z coordinate
-                || Math.abs(
-                        MathUtil.angleModulus(
-                            observation.pose().getRotation().toRotation2d().getRadians()
-                                - DriveSubsystem.getInstance().getRotation().getRadians()))
-                    > maxHeadingDifference // Vision heading disagrees with gyro
 
                 // Must be within the field boundaries
                 || observation.pose().getX() < 0.0


### PR DESCRIPTION
Added stdev boost while & immediately after going over bump to help pose estimate lock back in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vision boost mode that temporarily enhances vision system reliability when the robot enters designated bump zones, with automatic decay after exiting.

* **Improvements**
  * Increased flywheel passing accuracy by implementing tighter speed tolerance thresholds, improving consistency in passing operations.
  * Recalibrated baseline vision measurement uncertainties to enhance overall localization accuracy and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->